### PR TITLE
^ よりも λ に寄せる

### DIFF
--- a/src/to_string/ecmascript/expression.rs
+++ b/src/to_string/ecmascript/expression.rs
@@ -78,10 +78,12 @@ impl<'a> Compact<'a> {
                     .join(", ");
 
                 match **e {
-                    Compact::Variable(label) | Compact::Symbol(label) => {
+                    Compact::Variable(label) => {
                         format!("{}({})", label, args)
                     }
-
+                    Compact::Symbol(label) => {
+                        format!(":{}({})", label, args)
+                    }
                     _ => {
                         format!("({})({})", e.to_string(), args)
                     }
@@ -125,6 +127,9 @@ mod tests {
 
         let e = expr::a("x", "y");
         assert_eq!(ECMAScriptStyle(&e).to_string(), "x(y)");
+
+        let e = expr::a(":x", ":y");
+        assert_eq!(ECMAScriptStyle(&e).to_string(), ":x(:y)");
 
         let e = expr::a(expr::a("x", "y"), "z");
         assert_eq!(ECMAScriptStyle(&e).to_string(), "x(y, z)");

--- a/src/to_string/lazy_k/command.rs
+++ b/src/to_string/lazy_k/command.rs
@@ -81,7 +81,7 @@ mod tests {
         assert_eq!(command::eval(expr::v("a")).to_string(), "a");
         assert_eq!(command::eval(expr::s("a")).to_string(), ":a");
         assert_eq!(command::eval(expr::a("a", "b")).to_string(), "`ab");
-        assert_eq!(command::eval(expr::l("x", "y")).to_string(), "^x.y");
+        assert_eq!(command::eval(expr::l("x", "y")).to_string(), "λx.y");
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod tests {
         assert_eq!(command::eval_last(expr::v("a")).to_string(), "! a");
         assert_eq!(command::eval_last(expr::s("a")).to_string(), "! :a");
         assert_eq!(command::eval_last(expr::a("a", "b")).to_string(), "! `ab");
-        assert_eq!(command::eval_last(expr::l("x", "y")).to_string(), "! ^x.y");
+        assert_eq!(command::eval_last(expr::l("x", "y")).to_string(), "! λx.y");
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
         );
         assert_eq!(
             command::eval_head(42, expr::l("x", "y")).to_string(),
-            "!42 ^x.y"
+            "!42 λx.y"
         );
     }
 
@@ -116,7 +116,7 @@ mod tests {
         );
         assert_eq!(
             command::eval_tail(42, expr::l("x", "y")).to_string(),
-            "!-42 ^x.y"
+            "!-42 λx.y"
         );
     }
 

--- a/src/to_string/lazy_k/expression.rs
+++ b/src/to_string/lazy_k/expression.rs
@@ -100,7 +100,7 @@ impl Display for Token<'_> {
         match self {
             Token::UpperIdent(i) | Token::LowerIdent(i) => write!(f, "{}", i),
             Token::Apply => write!(f, "`"),
-            Token::Lambda => write!(f, "^"),
+            Token::Lambda => write!(f, "λ"),
             Token::Dot => write!(f, "."),
         }
     }
@@ -132,14 +132,14 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        assert_eq!(LazyKStyle(&expr::l("x", "y")).to_string(), "^x.y");
+        assert_eq!(LazyKStyle(&expr::l("x", "y")).to_string(), "λx.y");
         assert_eq!(
             LazyKStyle(&expr::l("x", expr::a("y", "z"))).to_string(),
-            "^x.`yz"
+            "λx.`yz"
         );
         assert_eq!(
             LazyKStyle(&expr::l("X", expr::a("y", "z"))).to_string(),
-            "^X.`yz"
+            "λX.`yz"
         );
         assert_eq!(LazyKStyle(&expr::a("x", "y")).to_string(), "`xy");
         assert_eq!(LazyKStyle(&expr::a("x", "Y")).to_string(), "`xY");


### PR DESCRIPTION
- Lazy_K スタイルで表示するときに `^` よりも `λ` を使う
- 複数の λ をまとめる記法を認める
  - ```^x.^y.^z.``xz`yz``` → ```^xyz.``xz`yz```
- 表示のバグを直す
  - Apply { lhs: ":a", rhs: ":b" } → `a(:b)` となってしまっていた
  - 正しくは `:a(:b)`