### PR TITLE
`ex.` → `e.g.`

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -49,14 +49,14 @@
               <input type="radio" name="tuber_display_style" value="ECMAScript">
               <span>
                 ECMAScript Style
-                <small>ex. <code>(x => f(x))(y)</code></small>
+                <small>e.g. <code>(x => f(x))(y)</code></small>
               </span>
             </label>
             <label>
               <input type="radio" name="tuber_display_style" value="Lazy_K">
               <span>
                 Lazy_K Style
-                <small>ex. <code>`λx.`fx y</code></small>
+                <small>e.g. <code>`λx.`fx y</code></small>
               </span>
             </label>
           </fieldset>


### PR DESCRIPTION
https://twitter.com/bd_gfngfn/status/1746516852648579506
![スクリーンショット 2024-01-30 22 27 36](https://github.com/todays-mitsui/wasm-mogul/assets/3040456/58cea275-24ac-435b-926c-f119612ded97)
